### PR TITLE
Add Makefile for pg_llm extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+EXTENSION = pg_llm
+MODULE_big = pg_llm
+
+SRCS := $(wildcard src/*.c)
+OBJS := $(SRCS:.c=.o)
+
+DATA = \
+sql/pg_llm--0.1.0.sql \
+sql/llm_block_forward.sql \
+sql/llm_backprop.sql
+
+PG_CPPFLAGS += -I$(srcdir)/src
+
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)


### PR DESCRIPTION
## Summary
- add a PGXS-based Makefile that builds the pg_llm extension as a single shared library
- include all C sources from src/ and install the SQL files with the extension

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16538a65c8328ba84641eab14d11e