### PR TITLE
Add CI workflow for building extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install PostgreSQL build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential postgresql-server-dev-all
+          sudo apt-get install -y build-essential postgresql-server-dev-16
 
       - name: Build extension
         run: |


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs PostgreSQL build dependencies
- compile the pg_llm extension on push and pull requests targeting main

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68e165a53b148328a7d10ef05762b89f