### PR TITLE
Fix GPT-2 attention indexing and add regression harness

### DIFF
--- a/sql/llm_attention_regress.sql
+++ b/sql/llm_attention_regress.sql
@@ -1,0 +1,21 @@
+-- Regression harness for pg_llm_attention.
+--
+-- Compares the C implementation against a precomputed GPT-2 style
+-- attention result for a tiny fixture (T=2, D=4, n_head=2).  The
+-- fixtures were generated via a float32 NumPy reference implementation
+-- mirroring GPT-2 attention math.
+WITH fixture AS (
+    SELECT
+        decode('5151fe3e28950dbeebce253fa4f2c23fe7c56fbe99c16fbea523ca3f9a76443f', 'hex')::bytea AS x,
+        decode('f25ef0be37e50a3f1545edbe2174eebef5c4773e5ee6f4bf1ccadcbf13f20fbf73a481bf07e5a03e447468bf5ec6b4bf619abb3fe73167be3a4c8a3d265eb6bfab5c0bbf622be33dc25393bf7e5bc03e75c319bfe25895be72091abf7417ed3f77235dbc126387bf4e92523f9b449cbf57e0553e78d6fabf0002aabffe95493e250c3d3f2b7b2f3e02d9ecbd432a9abe3540bdbfb64738bfd8d8ebbec84f873fbdeeaf3e4dabe1bf56eea53e8129c5bec34a2dbfd1961c3fcbf7833f60686e3f', 'hex')::bytea AS w_qkv,
+        decode('f6d656bf16519ebe5c9ba93e53bd793f5356f5be631d3ebe629c8dbf4c1d99bfb101503f4699ad3f0b7a93bdc473803f5b28b93e912625bfd808b93e62dec43f', 'hex')::bytea AS w_o,
+        decode('450f9e3f76d8b63fa2cdd6bf2a0f64bfcdb3593fc43ca13f2d2eb6bf9b0cf0be', 'hex')::bytea AS expected
+)
+SELECT
+    actual_hex,
+    encode(expected, 'hex') AS expected_hex,
+    actual_hex = encode(expected, 'hex') AS matches
+FROM fixture,
+LATERAL (
+    SELECT encode(pg_llm_attention(x, w_qkv, w_o, 2, 2, 4), 'hex') AS actual_hex
+) ref;


### PR DESCRIPTION
## Summary
- reshape the Q/K/V projection into dedicated buffers so each head indexes its own token slice
- update the score and value accumulation loops to use per-token base offsets
- add a SQL harness that compares pg_llm_attention against a float32 GPT-2 reference fixture

## Testing
- make *(fails: pgxs.mk not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1665e69588328a454a9bf5f62851f