### PR TITLE
Fix pg_llm extension build prerequisites

### DIFF
--- a/src/pg_llm.c
+++ b/src/pg_llm.c
@@ -1,5 +1,14 @@
 #include "pg_llm.h"
 
+PG_MODULE_MAGIC;
+
+PG_FUNCTION_INFO_V1(pg_llm_matmul);
+PG_FUNCTION_INFO_V1(pg_llm_add);
+PG_FUNCTION_INFO_V1(pg_llm_gelu);
+PG_FUNCTION_INFO_V1(pg_llm_softmax);
+PG_FUNCTION_INFO_V1(pg_llm_layernorm);
+PG_FUNCTION_INFO_V1(pg_llm_cross_entropy);
+
 /* ------------------ MATMUL ------------------ */
 Datum pg_llm_matmul(PG_FUNCTION_ARGS)
 {

--- a/src/pg_llm.h
+++ b/src/pg_llm.h
@@ -5,17 +5,17 @@
 #include "fmgr.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
+#include "funcapi.h"
+#include "executor/spi.h"
 #include <math.h>
 
-PG_MODULE_MAGIC;
-
 /* Function declarations */
-PG_FUNCTION_INFO_V1(pg_llm_matmul);
-PG_FUNCTION_INFO_V1(pg_llm_add);
-PG_FUNCTION_INFO_V1(pg_llm_gelu);
-PG_FUNCTION_INFO_V1(pg_llm_softmax);
-PG_FUNCTION_INFO_V1(pg_llm_layernorm);
-PG_FUNCTION_INFO_V1(pg_llm_cross_entropy);
+extern Datum pg_llm_matmul(PG_FUNCTION_ARGS);
+extern Datum pg_llm_add(PG_FUNCTION_ARGS);
+extern Datum pg_llm_gelu(PG_FUNCTION_ARGS);
+extern Datum pg_llm_softmax(PG_FUNCTION_ARGS);
+extern Datum pg_llm_layernorm(PG_FUNCTION_ARGS);
+extern Datum pg_llm_cross_entropy(PG_FUNCTION_ARGS);
 
 /* Utility helpers */
 static inline float* as_float(bytea *b) {

--- a/src/pg_llm_checkpoint.c
+++ b/src/pg_llm_checkpoint.c
@@ -7,8 +7,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <zlib.h>
-#include <json-c/json.h>
-#include "numpy/ndarrayobject.h"   /* if available */
 
 typedef struct npy_header_t
 {


### PR DESCRIPTION
## Summary
- define the PostgreSQL module magic block and PG_FUNCTION_INFO macros once in pg_llm.c to avoid duplicate symbols at link time
- expose function prototypes in pg_llm.h and include the SPI/funcapi headers required by checkpoint code
- drop unused json-c/numpy includes that conflicted with PostgreSQL symbols during compilation

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68e16a58732c83288bb337abf41e2040