### PR TITLE
Fix C90 declaration order to enable clean build

### DIFF
--- a/src/pg_llm.c
+++ b/src/pg_llm.c
@@ -18,11 +18,19 @@ Datum pg_llm_matmul(PG_FUNCTION_ARGS)
     int k = PG_GETARG_INT32(3);
     int n = PG_GETARG_INT32(4);
 
+    size_t expected_a;
+    size_t expected_b;
+    size_t out_bytes;
+    bytea *out;
+    float *A;
+    float *B;
+    float *C;
+
     if (m <= 0 || k <= 0 || n <= 0)
         ereport(ERROR, (errmsg("pg_llm_matmul requires positive matrix dimensions")));
 
-    size_t expected_a = (size_t) m * k * sizeof(float);
-    size_t expected_b = (size_t) k * n * sizeof(float);
+    expected_a = (size_t) m * k * sizeof(float);
+    expected_b = (size_t) k * n * sizeof(float);
     if (nbytes(a) != expected_a)
         ereport(ERROR,
                 (errmsg("pg_llm_matmul expected left matrix of %d x %d elements", m, k)));
@@ -30,11 +38,11 @@ Datum pg_llm_matmul(PG_FUNCTION_ARGS)
         ereport(ERROR,
                 (errmsg("pg_llm_matmul expected right matrix of %d x %d elements", k, n)));
 
-    float *A = as_float(a);
-    float *B = as_float(b);
-    size_t out_bytes = (size_t) m * n * sizeof(float);
-    bytea *out = bytea_alloc(out_bytes);
-    float *C = as_float(out);
+    A = as_float(a);
+    B = as_float(b);
+    out_bytes = (size_t) m * n * sizeof(float);
+    out = bytea_alloc(out_bytes);
+    C = as_float(out);
 
     for (int i = 0; i < m; i++) {
         for (int j = 0; j < n; j++) {
@@ -52,16 +60,22 @@ Datum pg_llm_add(PG_FUNCTION_ARGS)
 {
     bytea *a = PG_GETARG_BYTEA_P(0);
     bytea *b = PG_GETARG_BYTEA_P(1);
+    int n;
+    bytea *out;
+    float *A;
+    float *B;
+    float *C;
+
     ensure_same_size(a, b, "pg_llm_add");
 
-    int n = float_length(a, "pg_llm_add");
+    n = float_length(a, "pg_llm_add");
     (void) float_length(b, "pg_llm_add");
 
-    bytea *out = bytea_same_size(a);
+    out = bytea_same_size(a);
 
-    float *A = as_float(a);
-    float *B = as_float(b);
-    float *C = as_float(out);
+    A = as_float(a);
+    B = as_float(b);
+    C = as_float(out);
 
     for (int i = 0; i < n; i++)
         C[i] = A[i] + B[i];
@@ -75,15 +89,18 @@ Datum pg_llm_gelu(PG_FUNCTION_ARGS)
 {
     bytea *a = PG_GETARG_BYTEA_P(0);
     int n = float_length(a, "pg_llm_gelu");
+    bytea *out;
+    float *A;
+    float *Y;
+    const float k = 0.79788456f;   // √(2/π)
     if (n == 0)
         ereport(ERROR, (errmsg("pg_llm_gelu requires a non-empty input")));
 
-    bytea *out = bytea_same_size(a);
+    out = bytea_same_size(a);
 
-    float *A = as_float(a);
-    float *Y = as_float(out);
+    A = as_float(a);
+    Y = as_float(out);
 
-    const float k = 0.79788456f;   // √(2/π)
     for (int i = 0; i < n; i++) {
         float x = A[i];
         float x3 = x * x * x;
@@ -98,18 +115,22 @@ Datum pg_llm_softmax(PG_FUNCTION_ARGS)
 {
     bytea *a = PG_GETARG_BYTEA_P(0);
     int n = float_length(a, "pg_llm_softmax");
+    float *A;
+    bytea *out;
+    float *Y;
+    float maxv;
+    float sum = 0.0f;
     if (n == 0)
         ereport(ERROR, (errmsg("pg_llm_softmax requires a non-empty input")));
 
-    float *A = as_float(a);
+    A = as_float(a);
 
-    bytea *out = bytea_same_size(a);
-    float *Y = as_float(out);
+    out = bytea_same_size(a);
+    Y = as_float(out);
 
-    float maxv = A[0];
+    maxv = A[0];
     for (int i = 1; i < n; i++) if (A[i] > maxv) maxv = A[i];
 
-    float sum = 0.0f;
     for (int i = 0; i < n; i++) {
         Y[i] = expf(A[i] - maxv);
         sum += Y[i];
@@ -129,32 +150,38 @@ Datum pg_llm_layernorm(PG_FUNCTION_ARGS)
     float eps = PG_GETARG_FLOAT4(3);
 
     int n = float_length(x_b, "pg_llm_layernorm");
+    float *x;
+    float *gamma;
+    float *beta;
+    bytea *out;
+    float *y;
+    float mean = 0.f;
+    float var = 0.f;
+    float inv_std;
     if (n == 0)
         ereport(ERROR, (errmsg("pg_llm_layernorm requires a non-empty input")));
 
-    float *x = as_float(x_b);
-    float *gamma = as_float(gamma_b);
-    float *beta = as_float(beta_b);
+    x = as_float(x_b);
+    gamma = as_float(gamma_b);
+    beta = as_float(beta_b);
 
     (void) float_length(gamma_b, "pg_llm_layernorm");
     (void) float_length(beta_b, "pg_llm_layernorm");
     ensure_same_size(x_b, gamma_b, "pg_llm_layernorm");
     ensure_same_size(x_b, beta_b, "pg_llm_layernorm");
 
-    bytea *out = bytea_same_size(x_b);
-    float *y = as_float(out);
+    out = bytea_same_size(x_b);
+    y = as_float(out);
 
-    float mean = 0.f;
     for (int i = 0; i < n; i++) mean += x[i];
     mean /= n;
 
-    float var = 0.f;
     for (int i = 0; i < n; i++) {
         float d = x[i] - mean;
         var += d * d;
     }
     var /= n;
-    float inv_std = 1.0f / sqrtf(var + eps);
+    inv_std = 1.0f / sqrtf(var + eps);
 
     for (int i = 0; i < n; i++)
         y[i] = ((x[i] - mean) * inv_std) * gamma[i] + beta[i];
@@ -169,22 +196,26 @@ Datum pg_llm_cross_entropy(PG_FUNCTION_ARGS)
     int target = PG_GETARG_INT32(1);
 
     int n = float_length(logits_b, "pg_llm_cross_entropy");
+    float *z;
+    float maxv;
+    float sum = 0.0f;
+    float log_sum;
+    float loss;
     if (n == 0)
         ereport(ERROR, (errmsg("pg_llm_cross_entropy requires a non-empty logits vector")));
 
-    float *z = as_float(logits_b);
+    z = as_float(logits_b);
 
     if (target < 0 || target >= n)
         ereport(ERROR, (errmsg("pg_llm_cross_entropy target index %d out of bounds", target)));
 
-    float maxv = z[0];
+    maxv = z[0];
     for (int i = 1; i < n; i++) if (z[i] > maxv) maxv = z[i];
 
-    float sum = 0.0f;
     for (int i = 0; i < n; i++)
         sum += expf(z[i] - maxv);
-    float log_sum = logf(sum) + maxv;
+    log_sum = logf(sum) + maxv;
 
-    float loss = log_sum - z[target];  /* −log softmax[target] */
+    loss = log_sum - z[target];  /* −log softmax[target] */
     PG_RETURN_FLOAT4(loss);
 }

--- a/src/pg_llm_autograd.c
+++ b/src/pg_llm_autograd.c
@@ -2,10 +2,14 @@
 #include "executor/spi.h"
 #include "commands/trigger.h"
 
+static int tape_insert(const char *name, int *inputs, int n_in, int output, const char *extra_json) PG_USED_FOR_ASSERTS_ONLY;
+
 static int tape_insert(const char *name, int *inputs, int n_in, int output, const char *extra_json)
 {
+    StringInfoData buf;
+
     SPI_connect();
-    StringInfoData buf; initStringInfo(&buf);
+    initStringInfo(&buf);
     appendStringInfo(&buf,
         "INSERT INTO llm_tape(name,inputs,output,extra) VALUES('%s',ARRAY[", name);
     for(int i=0;i<n_in;i++){ if(i>0) appendStringInfoChar(&buf,','); appendStringInfo(&buf,"%d",inputs[i]); }


### PR DESCRIPTION
## Summary
- reorder variable declarations across the extension sources to satisfy PostgreSQL's C90 build requirements
- annotate unused helper functions and predeclare buffers in tokenizer and checkpoint utilities to silence warnings
- ensure attention and sampling helpers allocate temporaries up front before use

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68e1cdca86c88328a38bb6403489e419