### PR TITLE
Install clang-19 before build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential postgresql-server-dev-16
 
+      - name: Install clang-19
+        run: |
+          sudo apt-get install -y clang-19
+
       - name: Build extension
         run: |
           make


### PR DESCRIPTION
## Summary
- add a workflow step to install clang-19 before building the extension

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d7e7a668832882fa3d8370896571