### PR TITLE
Fix GPT-2 block residual connection

### DIFF
--- a/sql/llm_block_forward.sql
+++ b/sql/llm_block_forward.sql
@@ -17,6 +17,7 @@ DECLARE
     x BYTEA := input;
     attn BYTEA;
     mlp BYTEA;
+    residual2 BYTEA;
 BEGIN
     -- 1. LayerNorm
     x := pg_llm_layernorm(x, ln1_g, ln1_b, eps);
@@ -26,6 +27,7 @@ BEGIN
     x := pg_llm_add(input, attn);  -- residual 1
 
     -- 3. LayerNorm
+    residual2 := x;
     x := pg_llm_layernorm(x, ln2_g, ln2_b, eps);
 
     -- 4. Feed-Forward MLP
@@ -33,7 +35,7 @@ BEGIN
     mlp := pg_llm_gelu(mlp);
     mlp := pg_llm_matmul(mlp, w_proj, T, 4*D, D);
 
-    x := pg_llm_add(x, mlp);       -- residual 2
+    x := pg_llm_add(residual2, mlp);       -- residual 2
     RETURN x;
 END;
 $$ LANGUAGE plpgsql STRICT;


### PR DESCRIPTION
## Summary
- capture the pre-layernorm activations before the second normalization step in `llm_block_forward`
- apply the residual connection around the MLP using the saved activations to match GPT-2's pre-LN architecture

## Testing
- make check *(fails: PostgreSQL PGXS makefile not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2956577b08328943a751fe41fbf73