### PR TITLE
Normalize GPT-2 forward output with final layer norm

### DIFF
--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -106,7 +106,14 @@ BEGIN
     x := llm_embed(tokens, model, D);   -- we'll define this below
 
     -- 2. Forward pass through transformer
-    x := llm_forward_gpt2(x, n_layer, n_head, array_length(tokens,1), D);
+    x := llm_forward_gpt2(
+        x,
+        n_layer,
+        n_head,
+        array_length(tokens,1),
+        D,
+        (SELECT data FROM llm_param p WHERE p.model = model AND p.name = 'ln_f.weight'),
+        (SELECT data FROM llm_param p WHERE p.model = model AND p.name = 'ln_f.bias'));
 
     -- 3. Final linear projection (tie weights with token_emb)
     logits := pg_llm_matmul(x,


### PR DESCRIPTION
## Summary
- apply the GPT-2 final layer normalization in `llm_forward_gpt2` using the stored `ln_f` parameters
- allow callers to provide the final layer norm tensors while still falling back to table lookups when omitted
- pass the `ln_f` tensors from `llm_loss` so training uses the correct normalization

## Testing
- `make installcheck` *(fails: PostgreSQL server development headers/PGXS not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e29562e1b883288ad0151e1406ba5b