### PR TITLE
Add dropout primitive and training coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ sql/pg_llm--0.1.0.sql \
 sql/llm_block_forward.sql \
 sql/llm_backprop.sql
 
-REGRESS = adamw
+REGRESS = adamw dropout
+REGRESS_OPTS = --dlpath=$(abs_builddir)
 
 PG_CPPFLAGS += -I$(srcdir)/src
 

--- a/expected/dropout.out
+++ b/expected/dropout.out
@@ -1,0 +1,28 @@
+DROP FUNCTION
+CREATE FUNCTION
+SET
+             label             |                            input_hex                             |                            output_hex                            | exact_match 
+-------------------------------+------------------------------------------------------------------+------------------------------------------------------------------+-------------
+ dropout inference passthrough | 0000803f0000803f0000803f0000803f0000803f0000803f0000803f0000803f | 0000803f0000803f0000803f0000803f0000803f0000803f0000803f0000803f | t
+(1 row)
+
+ setseed 
+---------
+ 
+(1 row)
+
+          label          |                            output_hex                            
+-------------------------+------------------------------------------------------------------
+ dropout training sample | e4388e3fe4388e3fe4388e3fe4388e3fe4388e3fe4388e3fe4388e3fe4388e3f
+(1 row)
+
+ setseed 
+---------
+ 
+(1 row)
+
+         label          | mean_val | approx_expected | zero_count | total_count | scaled_matches 
+------------------------+----------+-----------------+------------+-------------+----------------
+ dropout training stats | 1.002604 | t               |         25 |         256 | t
+(1 row)
+

--- a/sql/dropout.sql
+++ b/sql/dropout.sql
@@ -1,0 +1,103 @@
+DROP FUNCTION IF EXISTS pg_llm_dropout(BYTEA, REAL, BOOLEAN);
+CREATE FUNCTION pg_llm_dropout(input BYTEA, p REAL, training BOOLEAN)
+RETURNS BYTEA
+AS '/workspace/pg_gpt2/pg_llm', 'pg_llm_dropout'
+LANGUAGE C STRICT;
+
+SET extra_float_digits = 3;
+
+WITH ones AS (
+    SELECT string_agg(le_bytes, ''::bytea ORDER BY ord) AS input
+    FROM generate_series(1, 8) WITH ORDINALITY AS gs(_, ord)
+    CROSS JOIN LATERAL (
+        SELECT set_byte(
+                   set_byte(
+                       set_byte(
+                           set_byte('\x00000000'::bytea, 0, get_byte(be, 3)),
+                           1, get_byte(be, 2)),
+                       2, get_byte(be, 1)),
+                   3, get_byte(be, 0)) AS le_bytes
+        FROM (SELECT pg_catalog.float4send(1.0::float4) AS be) s
+    )
+)
+SELECT 'dropout inference passthrough' AS label,
+       encode(input, 'hex') AS input_hex,
+       encode(out_bytes, 'hex') AS output_hex,
+       out_bytes = input AS exact_match
+FROM ones,
+LATERAL (
+    SELECT pg_llm_dropout(input, 0.1::float4, false) AS out_bytes
+) d;
+
+SELECT setseed(0.5);
+
+WITH ones AS (
+    SELECT string_agg(le_bytes, ''::bytea ORDER BY ord) AS input
+    FROM generate_series(1, 8) WITH ORDINALITY AS gs(_, ord)
+    CROSS JOIN LATERAL (
+        SELECT set_byte(
+                   set_byte(
+                       set_byte(
+                           set_byte('\x00000000'::bytea, 0, get_byte(be, 3)),
+                           1, get_byte(be, 2)),
+                       2, get_byte(be, 1)),
+                   3, get_byte(be, 0)) AS le_bytes
+        FROM (SELECT pg_catalog.float4send(1.0::float4) AS be) s
+    )
+)
+SELECT 'dropout training sample' AS label,
+       encode(pg_llm_dropout(input, 0.1::float4, true), 'hex') AS output_hex
+FROM ones;
+
+SELECT setseed(0.5);
+
+WITH ones AS (
+    SELECT string_agg(le_bytes, ''::bytea ORDER BY ord) AS input
+    FROM generate_series(1, 256) WITH ORDINALITY AS gs(_, ord)
+    CROSS JOIN LATERAL (
+        SELECT set_byte(
+                   set_byte(
+                       set_byte(
+                           set_byte('\x00000000'::bytea, 0, get_byte(be, 3)),
+                           1, get_byte(be, 2)),
+                       2, get_byte(be, 1)),
+                   3, get_byte(be, 0)) AS le_bytes
+        FROM (SELECT pg_catalog.float4send(1.0::float4) AS be) s
+    )
+),
+ drop_samples AS (
+    SELECT pg_llm_dropout(input, 0.1::float4, true) AS out_bytes
+    FROM ones
+ ),
+ chunks AS (
+    SELECT c.chunk
+    FROM drop_samples,
+         LATERAL generate_series(0, (octet_length(out_bytes) / 4) - 1) AS g(idx)
+         CROSS JOIN LATERAL (
+             SELECT substring(out_bytes FROM g.idx * 4 + 1 FOR 4) AS chunk
+         ) AS c
+ ),
+ scale_bytes AS (
+    SELECT set_byte(
+               set_byte(
+                   set_byte(
+                       set_byte('\x00000000'::bytea, 0, get_byte(be, 3)),
+                       1, get_byte(be, 2)),
+                   2, get_byte(be, 1)),
+               3, get_byte(be, 0)) AS scaled_chunk
+    FROM (SELECT pg_catalog.float4send((1.0 / (1.0 - 0.1))::float4) AS be) s
+),
+ stats AS (
+    SELECT
+        SUM(CASE WHEN chunk = '\x00000000'::bytea THEN 1 ELSE 0 END) AS zero_count,
+        SUM(CASE WHEN chunk = scale_bytes.scaled_chunk THEN 1 ELSE 0 END) AS scaled_count,
+        COUNT(*) AS total_count
+    FROM chunks, scale_bytes
+)
+SELECT 'dropout training stats' AS label,
+       ROUND((scaled_count::numeric * (1.0 / (1.0 - 0.1))) / total_count, 6) AS mean_val,
+        ABS((scaled_count::numeric * (1.0 / (1.0 - 0.1))) / total_count - 1.0) < 0.05 AS approx_expected,
+       zero_count,
+       total_count,
+       scaled_count = total_count - zero_count AS scaled_matches
+FROM stats;

--- a/sql/llm_block_forward.sql
+++ b/sql/llm_block_forward.sql
@@ -15,7 +15,9 @@ CREATE OR REPLACE FUNCTION llm_block_forward(
     n_head INT,
     T INT,
     D INT,
-    eps FLOAT4 DEFAULT 1e-5)
+    eps FLOAT4 DEFAULT 1e-5,
+    dropout_p FLOAT4 DEFAULT 0.1,
+    training BOOLEAN DEFAULT false)
 RETURNS BYTEA AS $$
 DECLARE
     x BYTEA := input;
@@ -28,6 +30,7 @@ BEGIN
 
     -- 2. Self-Attention
     attn := pg_llm_attention(x, w_qkv, b_qkv, w_o, b_o, n_head, T, D);
+    attn := pg_llm_dropout(attn, dropout_p, training);
     x := pg_llm_add(input, attn);  -- residual 1
 
     -- 3. LayerNorm
@@ -40,6 +43,7 @@ BEGIN
     mlp := pg_llm_gelu(mlp);
     mlp := pg_llm_matmul(mlp, w_proj, T, 4*D, D);
     mlp := pg_llm_add(mlp, b_proj);
+    mlp := pg_llm_dropout(mlp, dropout_p, training);
 
     x := pg_llm_add(residual2, mlp);       -- residual 2
     RETURN x;
@@ -53,7 +57,9 @@ CREATE OR REPLACE FUNCTION llm_forward_gpt2(
     T INT,
     D INT,
     ln_f_weight BYTEA DEFAULT NULL,
-    ln_f_bias BYTEA DEFAULT NULL)
+    ln_f_bias BYTEA DEFAULT NULL,
+    dropout_p FLOAT4 DEFAULT 0.1,
+    training BOOLEAN DEFAULT false)
 RETURNS BYTEA AS $$
 DECLARE
     x BYTEA := input;
@@ -127,7 +133,9 @@ BEGIN
             ln1_b,
             ln2_g,
             ln2_b,
-            n_head, T, D);
+            n_head, T, D,
+            dropout_p => dropout_p,
+            training => training);
     END LOOP;
     IF final_weight IS NULL THEN
         SELECT data INTO final_weight

--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -28,6 +28,11 @@ RETURNS FLOAT4
 AS 'MODULE_PATHNAME', 'pg_llm_cross_entropy'
 LANGUAGE C STRICT;
 
+CREATE FUNCTION pg_llm_dropout(input BYTEA, p FLOAT4, training BOOLEAN DEFAULT false)
+RETURNS BYTEA
+AS 'MODULE_PATHNAME', 'pg_llm_dropout'
+LANGUAGE C STRICT;
+
 CREATE FUNCTION pg_llm_attention(
     x BYTEA,
     w_qkv BYTEA,
@@ -119,7 +124,9 @@ BEGIN
         array_length(tokens,1),
         D,
         (SELECT data FROM llm_param p WHERE p.model = model AND p.name = 'ln_f.weight'),
-        (SELECT data FROM llm_param p WHERE p.model = model AND p.name = 'ln_f.bias'));
+        (SELECT data FROM llm_param p WHERE p.model = model AND p.name = 'ln_f.bias'),
+        dropout_p => 0.1::float4,
+        training => true);
 
     -- 3. Final linear projection (tie weights with token_emb)
     logits := pg_llm_matmul(x,

--- a/src/pg_llm.h
+++ b/src/pg_llm.h
@@ -16,6 +16,7 @@ extern Datum pg_llm_gelu(PG_FUNCTION_ARGS);
 extern Datum pg_llm_softmax(PG_FUNCTION_ARGS);
 extern Datum pg_llm_layernorm(PG_FUNCTION_ARGS);
 extern Datum pg_llm_cross_entropy(PG_FUNCTION_ARGS);
+extern Datum pg_llm_dropout(PG_FUNCTION_ARGS);
 
 /* Utility helpers */
 static inline float* as_float(bytea *b) {


### PR DESCRIPTION
## Summary
- implement a pg_llm_dropout C primitive that samples with PostgreSQL's RNG and rescales kept activations
- pass training flags/dropout rates through llm_block_forward and llm_forward_gpt2 so residual paths mirror GPT-2 behaviour
- add a regression script that exercises dropout statistics and preserves inference output

## Testing
- `psql -p 55432 -U postgres -f sql/dropout.sql`
- `make installcheck` *(fails: missing pg_llm_optim shared library for adamw harness)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a4a282c88328a7c1af482367e604