### PR TITLE
Add tensor helper functions for autograd support

### DIFF
--- a/sql/llm_backprop.sql
+++ b/sql/llm_backprop.sql
@@ -26,11 +26,11 @@ BEGIN
             -- dA = dY @ Bᵀ, dB = Aᵀ @ dY
             UPDATE llm_tensor_rt
               SET grad = COALESCE(grad, pg_llm_zeros_like(data))
-                        + pg_llm_matmul(grad, pg_llm_transpose(b), m,n,k)
+                        + pg_llm_matmul(grad, pg_llm_transpose(b, k, n), m,n,k)
               WHERE id=node.inputs[1];
             UPDATE llm_tensor_rt
               SET grad = COALESCE(grad, pg_llm_zeros_like(data))
-                        + pg_llm_matmul(pg_llm_transpose(a), grad, k,m,n)
+                        + pg_llm_matmul(pg_llm_transpose(a, m, k), grad, k,m,n)
               WHERE id=node.inputs[2];
               ELSIF node.name='softmax' THEN
     UPDATE llm_tensor_rt

--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -33,6 +33,21 @@ RETURNS BYTEA
 AS 'MODULE_PATHNAME', 'pg_llm_dropout'
 LANGUAGE C STRICT;
 
+CREATE FUNCTION pg_llm_ones_like(src BYTEA)
+RETURNS BYTEA
+AS 'MODULE_PATHNAME', 'pg_llm_ones_like'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION pg_llm_zeros_like(src BYTEA)
+RETURNS BYTEA
+AS 'MODULE_PATHNAME', 'pg_llm_zeros_like'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION pg_llm_transpose(src BYTEA, rows INT, cols INT)
+RETURNS BYTEA
+AS 'MODULE_PATHNAME', 'pg_llm_transpose'
+LANGUAGE C STRICT;
+
 CREATE FUNCTION pg_llm_attention(
     x BYTEA,
     w_qkv BYTEA,

--- a/src/pg_llm.h
+++ b/src/pg_llm.h
@@ -17,6 +17,9 @@ extern Datum pg_llm_softmax(PG_FUNCTION_ARGS);
 extern Datum pg_llm_layernorm(PG_FUNCTION_ARGS);
 extern Datum pg_llm_cross_entropy(PG_FUNCTION_ARGS);
 extern Datum pg_llm_dropout(PG_FUNCTION_ARGS);
+extern Datum pg_llm_ones_like(PG_FUNCTION_ARGS);
+extern Datum pg_llm_zeros_like(PG_FUNCTION_ARGS);
+extern Datum pg_llm_transpose(PG_FUNCTION_ARGS);
 
 /* Utility helpers */
 static inline float* as_float(bytea *b) {
@@ -35,6 +38,15 @@ static inline bytea* bytea_alloc(Size payload_bytes) {
 
 static inline bytea* bytea_same_size(bytea *src) {
     return bytea_alloc(nbytes(src));
+}
+
+static inline bytea* bytea_constant_like(bytea *src, const char *fn_name, float value) {
+    int n = float_length(src, fn_name);
+    bytea *out = bytea_same_size(src);
+    float *dst = as_float(out);
+    for (int i = 0; i < n; i++)
+        dst[i] = value;
+    return out;
 }
 
 static inline int float_length(bytea *b, const char *fn_name) {


### PR DESCRIPTION
## Summary
- add SQL bindings and C implementations for pg_llm_ones_like, pg_llm_zeros_like, and pg_llm_transpose
- expose a shared helper to clone tensors filled with a constant for gradient allocation
- update the backprop SQL to supply matrix dimensions when calling the new transpose helper

## Testing
- make *(fails: PostgreSQL server development package not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2acf3e28483289219b247dfb1cc87