### PR TITLE
Add autograd mode table and guard tape recording

### DIFF
--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -358,6 +358,11 @@ CREATE UNLOGGED TABLE llm_tape (
     extra JSONB            -- shape info, constants (e.g., eps, dims)
 );
 
+-- guard flag that toggles autograd recording
+CREATE UNLOGGED TABLE llm_autograd_mode (
+    flag BOOL NOT NULL
+);
+
 -- store actual data buffers
 CREATE UNLOGGED TABLE llm_tensor_rt (
     id SERIAL PRIMARY KEY,

--- a/src/pg_llm_autograd.c
+++ b/src/pg_llm_autograd.c
@@ -2,13 +2,46 @@
 #include "executor/spi.h"
 #include "commands/trigger.h"
 
+static bool autograd_enabled(void);
 static int tape_insert(const char *name, int *inputs, int n_in, int output, const char *extra_json) PG_USED_FOR_ASSERTS_ONLY;
+
+static bool
+autograd_enabled(void)
+{
+    bool enabled = false;
+    int ret;
+    bool isnull;
+
+    ret = SPI_execute("SELECT flag FROM llm_autograd_mode LIMIT 1", true, 1);
+    if (ret != SPI_OK_SELECT)
+        ereport(ERROR,
+                (errmsg("failed to query llm_autograd_mode (SPI_execute returned %d)", ret)));
+
+    if (SPI_processed > 0)
+    {
+        Datum datum = SPI_getbinval(SPI_tuptable->vals[0],
+                                    SPI_tuptable->tupdesc,
+                                    1,
+                                    &isnull);
+        if (!isnull)
+            enabled = DatumGetBool(datum);
+    }
+
+    return enabled;
+}
 
 static int tape_insert(const char *name, int *inputs, int n_in, int output, const char *extra_json)
 {
     StringInfoData buf;
 
     SPI_connect();
+
+    if (!autograd_enabled())
+    {
+        SPI_finish();
+        return output;
+    }
+
     initStringInfo(&buf);
     appendStringInfo(&buf,
         "INSERT INTO llm_tape(name,inputs,output,extra) VALUES('%s',ARRAY[", name);


### PR DESCRIPTION
## Summary
- define the llm_autograd_mode table used to toggle autograd recording
- gate the tape insertion helper on the llm_autograd_mode flag so operations are recorded only when enabled

## Testing
- make *(fails: PostgreSQL PGXS makefile not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b4b4cff0832884e4481d214a809e