### PR TITLE
Add llm_autograd_mode table to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If PostgreSQL is installed somewhere custom, set the `PG_CONFIG` environment var
 | `llm_param` | Model parameters, gradients, optimizer state. |
 | `llm_dataset` | Tokenized training sequences. |
 | `llm_tape` / `llm_tensor_rt` | Computational graph and runtime tensors for autograd. |
+| `llm_autograd_mode` | Single-row toggle that signals when forward passes should record autograd tape entries. |
 | `llm_checkpoint` | Versioned checkpoint metadata and file paths. |
 | `llm_bpe_vocab` / `llm_bpe_merges` | GPT-2 tokenizer vocabulary and merge ranks. |
 | `llm_train_log` | Per-step learning rate and loss history. |

--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -113,6 +113,11 @@ CREATE UNLOGGED TABLE llm_tensor (
     requires_grad BOOL DEFAULT false
 );
 
+-- Single-row toggle to enable/disable autograd recording during forward passes
+CREATE UNLOGGED TABLE llm_autograd_mode (
+    flag BOOLEAN PRIMARY KEY
+);
+
 CREATE TABLE llm_train_log (
     model TEXT,
     step INT,


### PR DESCRIPTION
## Summary
- add a single-row llm_autograd_mode table to control whether autograd recording is enabled during a forward pass
- document the table in the README key tables section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b4fa54708328a37a1308056c9e9b