### PR TITLE
Add cross entropy backward kernel

### DIFF
--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -28,6 +28,11 @@ RETURNS FLOAT4
 AS 'MODULE_PATHNAME', 'pg_llm_cross_entropy'
 LANGUAGE C STRICT;
 
+CREATE FUNCTION pg_llm_cross_entropy_backward(logits BYTEA, target INT)
+RETURNS BYTEA
+AS 'MODULE_PATHNAME', 'pg_llm_cross_entropy_backward'
+LANGUAGE C STRICT;
+
 CREATE FUNCTION pg_llm_dropout(input BYTEA, p FLOAT4, training BOOLEAN DEFAULT false)
 RETURNS BYTEA
 AS 'MODULE_PATHNAME', 'pg_llm_dropout'

--- a/src/pg_llm.h
+++ b/src/pg_llm.h
@@ -24,6 +24,7 @@ extern Datum pg_llm_gelu_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_softmax_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_layernorm_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_dropout_backward(PG_FUNCTION_ARGS);
+extern Datum pg_llm_cross_entropy_backward(PG_FUNCTION_ARGS);
 
 /* Optimized kernels */
 extern void pg_llm_fast_gemm(const float *A, const float *B, float *C,


### PR DESCRIPTION
## Summary
- implement the `pg_llm_cross_entropy_backward` kernel to produce logits gradients for cross-entropy loss
- expose the new kernel to SQL and add its declaration to the extension headers
- update `llm_backprop` to use the new kernel when replaying `cross_entropy` tape nodes

## Testing
- make *(fails: PostgreSQL PGXS makefile not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b4d083ac8328b563fc5d795fe9b0