### PR TITLE
Document autograd runtime workflow

### DIFF
--- a/sql/llm_backprop.sql
+++ b/sql/llm_backprop.sql
@@ -10,6 +10,8 @@ BEGIN
     -- seed gradient of final output = 1
     UPDATE llm_tensor_rt SET grad = pg_llm_ones_like(data) WHERE id=start_id;
 
+    -- Replay the tape in reverse order.  Each op name recorded during the
+    -- forward pass determines which gradient kernel we invoke.
     FOR node IN SELECT * FROM llm_tape ORDER BY id DESC LOOP
         IF node.name='add' THEN
             UPDATE llm_tensor_rt

--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -172,7 +172,10 @@ BEGIN
         dropout_p => dropout_p,
         training => training);
 
-    -- 3. Final linear projection (tie weights with token_emb)
+    -- 3. Final linear projection (tie weights with token_emb).
+    --    When this concatenated matrix is handed to the matmul kernel the
+    --    runtime id must be registered via pg_llm_autograd_map_param so the
+    --    logits gradient is accumulated back into each `wte` row.
     logits := pg_llm_matmul(x,
         (SELECT string_agg(p.data::TEXT, '' ORDER BY p.token_id)::BYTEA
          FROM llm_param p

--- a/src/pg_llm_autograd.c
+++ b/src/pg_llm_autograd.c
@@ -212,6 +212,16 @@ pg_llm_autograd_record_tape(const char *name, int *inputs, int n_inputs, int out
     tape_insert(name, inputs, n_inputs, output, extra_json);
 }
 
+/*
+ * Register a parameter buffer with the autograd runtime so gradients can flow
+ * back to the owning (model, name, token_id) row.
+ *
+ * Call this immediately after materialising a parameter into a `bytea *` that
+ * will be passed to C kernels. This is especially important for buffers that
+ * are views over multiple parameters (e.g., the flattened tied embedding
+ * matrix) because autograd only sees runtime tensor ids. Without this mapping
+ * `llm_accumulate_grads` cannot copy grads back into `llm_param`.
+ */
 void
 pg_llm_autograd_map_param(const char *model,
                           const char *name,


### PR DESCRIPTION
## Summary
- document how autograd state is materialized, recorded, and replayed in the README
- clarify that pg_llm_autograd_map_param must be called when exposing parameter buffers, including tied embeddings
- explain in code comments how llm_backprop dispatches gradients across the recorded tape

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2c3dd4a0c832884d396897473665a