### PR TITLE
Optimize attention workspace and cleanup runtime tables

### DIFF
--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -268,6 +268,10 @@ BEGIN
     INSERT INTO llm_train_log(model, step, lr, loss)
     VALUES(model, step_count, lr, loss);
 
+    -- Free runtime autograd state eagerly so the next step starts clean
+    DELETE FROM llm_tape;
+    DELETE FROM llm_tensor_rt;
+
     RETURN loss;
 END;
 $$ LANGUAGE plpgsql;

--- a/src/llm_attention.c
+++ b/src/llm_attention.c
@@ -16,8 +16,11 @@ attention_compute(float *x, float *w_qkv, float *b_qkv,
     float *Q_chunk;
     float *score_chunk;
     float *context_chunk;
+    float *K_head_T;
+    float *V_head;
     float *proj;
     const int chunk_rows = Min(PG_LLM_ATTENTION_CHUNK, (int)T);
+    const int pack_block = 32;
 
     qkv = (float *) palloc((Size)T * 3 * D * sizeof(float));
     pg_llm_fast_gemm(x, w_qkv, qkv, T, D, 3 * D);
@@ -33,19 +36,33 @@ attention_compute(float *x, float *w_qkv, float *b_qkv,
     Q_chunk = (float *) palloc((Size)chunk_rows * head_dim * sizeof(float));
     score_chunk = (float *) palloc((Size)chunk_rows * T * sizeof(float));
     context_chunk = (float *) palloc((Size)chunk_rows * head_dim * sizeof(float));
+    K_head_T = (float *) palloc((Size)head_dim * T * sizeof(float));
+    V_head = (float *) palloc((Size)T * head_dim * sizeof(float));
 
     for (int h = 0; h < n_head; ++h) {
         int off = h * head_dim;
-        float *K_head_T = (float *) palloc((Size)head_dim * T * sizeof(float));
-        float *V_head = (float *) palloc((Size)T * head_dim * sizeof(float));
+        const float *K_head = K + off;
+        const float *V_head_src = V + off;
 
-        for (int t = 0; t < T; ++t) {
-            const float *k_src = K + (Size)t * D + off;
-            const float *v_src = V + (Size)t * D + off;
-            float *v_dst = V_head + (Size)t * head_dim;
-            memcpy(v_dst, v_src, head_dim * sizeof(float));
-            for (int d = 0; d < head_dim; ++d)
-                K_head_T[(Size)d * T + t] = k_src[d];
+        for (int t0 = 0; t0 < T; t0 += pack_block) {
+            int t_block = Min(pack_block, (int)T - t0);
+
+            for (int tt = 0; tt < t_block; ++tt) {
+                const float *v_src = V_head_src + (Size)(t0 + tt) * D;
+                float *v_dst = V_head + (Size)(t0 + tt) * head_dim;
+                memcpy(v_dst, v_src, head_dim * sizeof(float));
+            }
+
+            for (int d0 = 0; d0 < head_dim; d0 += pack_block) {
+                int d_block = Min(pack_block, head_dim - d0);
+                for (int dd = 0; dd < d_block; ++dd) {
+                    int d = d0 + dd;
+                    float *k_dst = K_head_T + (Size)d * T + t0;
+                    const float *k_src = K_head + (Size)t0 * D + d;
+                    for (int tt = 0; tt < t_block; ++tt)
+                        k_dst[tt] = k_src[(Size)tt * D];
+                }
+            }
         }
 
         for (int base = 0; base < T; base += chunk_rows) {
@@ -95,8 +112,6 @@ attention_compute(float *x, float *w_qkv, float *b_qkv,
             }
         }
 
-        pfree(K_head_T);
-        pfree(V_head);
     }
 
     proj = (float *) palloc((Size)T * D * sizeof(float));
@@ -109,6 +124,8 @@ attention_compute(float *x, float *w_qkv, float *b_qkv,
     memcpy(Y, proj, (Size)T * D * sizeof(float));
 
     pfree(proj);
+    pfree(V_head);
+    pfree(K_head_T);
     pfree(context_chunk);
     pfree(score_chunk);
     pfree(Q_chunk);


### PR DESCRIPTION
## Summary
- reuse per-head attention workspaces in `attention_compute` and block-pack key/value tensors to avoid repeated allocations
- eagerly clear `llm_tape` and `llm_tensor_rt` after each training step to keep runtime tables bounded

## Testing
- `make` *(fails: PostgreSQL PGXS makefile not found; server dev package missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c3d1fab48328865d90e2a7646e6a