### PR TITLE
Register materialized parameters with autograd registry

### DIFF
--- a/src/pg_llm.h
+++ b/src/pg_llm.h
@@ -31,7 +31,7 @@ extern Datum pg_llm_cross_entropy_backward(PG_FUNCTION_ARGS);
 extern bool pg_llm_autograd_enabled(void);
 extern int pg_llm_autograd_track_tensor(bytea *tensor, int ndims, const int *dims, bool requires_grad);
 extern void pg_llm_autograd_record_tape(const char *name, int *inputs, int n_inputs, int output, const char *extra_json);
-extern void pg_llm_autograd_map_param(const char *model, const char *name, int token_id, bytea *tensor, int ndims, const int *dims);
+extern Datum pg_llm_autograd_map_param(PG_FUNCTION_ARGS);
 
 /* Optimized kernels */
 extern void pg_llm_fast_gemm(const float *A, const float *B, float *C,

--- a/src/pg_llm_autograd.c
+++ b/src/pg_llm_autograd.c
@@ -16,6 +16,8 @@ typedef struct TensorRegistryEntry
 
 static HTAB *tensor_registry = NULL;
 
+PG_FUNCTION_INFO_V1(pg_llm_autograd_map_param);
+
 static void
 ensure_tensor_registry(void)
 {
@@ -212,13 +214,13 @@ pg_llm_autograd_record_tape(const char *name, int *inputs, int n_inputs, int out
     tape_insert(name, inputs, n_inputs, output, extra_json);
 }
 
-void
-pg_llm_autograd_map_param(const char *model,
-                          const char *name,
-                          int token_id,
-                          bytea *tensor,
-                          int ndims,
-                          const int *dims)
+static void
+pg_llm_autograd_map_param_impl(const char *model,
+                               const char *name,
+                               int token_id,
+                               bytea *tensor,
+                               int ndims,
+                               const int *dims)
 {
     Datum       values[4];
     bool        nulls[4] = {false, false, false, false};
@@ -248,4 +250,80 @@ pg_llm_autograd_map_param(const char *model,
         0);
     if (ret != SPI_OK_INSERT && ret != SPI_OK_UPDATE)
         ereport(ERROR, (errmsg("failed to upsert tensor map")));
+}
+
+Datum
+pg_llm_autograd_map_param(PG_FUNCTION_ARGS)
+{
+    text       *model_text;
+    text       *name_text;
+    int32       token_id;
+    bytea      *tensor;
+    ArrayType  *shape = NULL;
+    int        *dims = NULL;
+    int         ndims = 0;
+
+    if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2) || PG_ARGISNULL(3))
+        ereport(ERROR,
+                (errmsg("pg_llm_autograd_map_param requires non-null model, name, token_id, and tensor")));
+
+    model_text = PG_GETARG_TEXT_PP(0);
+    name_text = PG_GETARG_TEXT_PP(1);
+    token_id = PG_GETARG_INT32(2);
+    tensor = PG_GETARG_BYTEA_PP(3);
+
+    if (PG_NARGS() > 4 && !PG_ARGISNULL(4))
+    {
+        Datum  *elems;
+        bool   *nulls;
+        int     nelems;
+
+        shape = PG_GETARG_ARRAYTYPE_P(4);
+
+        if (ARR_NDIM(shape) > 1)
+            ereport(ERROR,
+                    (errmsg("pg_llm_autograd_map_param expects shape as a 1-D int array")));
+
+        deconstruct_array(shape,
+                          INT4OID,
+                          sizeof(int32),
+                          true,
+                          'i',
+                          &elems,
+                          &nulls,
+                          &nelems);
+
+        dims = (int *) palloc(sizeof(int) * nelems);
+        for (int i = 0; i < nelems; i++)
+        {
+            if (nulls[i])
+                ereport(ERROR,
+                        (errmsg("pg_llm_autograd_map_param does not accept NULL elements in shape")));
+            dims[i] = DatumGetInt32(elems[i]);
+        }
+        ndims = nelems;
+    }
+
+    if (SPI_connect() != SPI_OK_CONNECT)
+        ereport(ERROR, (errmsg("SPI_connect failed in pg_llm_autograd_map_param")));
+
+    PG_TRY();
+    {
+        pg_llm_autograd_map_param_impl(text_to_cstring(model_text),
+                                       text_to_cstring(name_text),
+                                       token_id,
+                                       tensor,
+                                       ndims,
+                                       dims);
+    }
+    PG_CATCH();
+    {
+        SPI_finish();
+        PG_RE_THROW();
+    }
+    PG_END_TRY();
+
+    SPI_finish();
+
+    PG_RETURN_VOID();
 }


### PR DESCRIPTION
## Summary
- expose pg_llm_autograd_map_param as a SQL-callable helper with optional shape metadata
- materialize parameters by registering them through the autograd map function instead of manually managing runtime IDs
- ensure the autograd map helper manages its own SPI context before inserting mappings

## Testing
- make installcheck *(fails: PostgreSQL PGXS makefile not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c3860ef8832896513ee3862d55fa