### PR TITLE
Fix wte gradient accumulation for tied embeddings

### DIFF
--- a/sql/llm_backprop.sql
+++ b/sql/llm_backprop.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION llm_backprop(start_id INT)
+CREATE OR REPLACE FUNCTION llm_backprop(start_id INT, p_model TEXT)
 RETURNS VOID AS $$
 DECLARE
     node RECORD;
@@ -6,6 +6,13 @@ DECLARE
     a_id INT; b_id INT;
     a BYTEA; b BYTEA;
     m INT; k INT; n INT;
+    b_grad BYTEA;
+    grad_rows BYTEA;
+    token_idx INT;
+    bytes_per_row INT;
+    wte_tensor_id INT;
+    chunk BYTEA;
+    has_mapping BOOLEAN;
 BEGIN
     -- seed gradient of final output = 1
     UPDATE llm_tensor_rt SET grad = pg_llm_ones_like(data) WHERE id=start_id;
@@ -32,6 +39,42 @@ BEGIN
               SET grad = COALESCE(grad, pg_llm_zeros_like(data))
                         + pg_llm_matmul(pg_llm_transpose(a, m, k), grad, k,m,n)
               WHERE id=node.inputs[2];
+
+            SELECT EXISTS(
+                       SELECT 1
+                         FROM llm_tensor_map
+                        WHERE tensor_id = node.inputs[2]
+                          AND model = p_model) INTO has_mapping;
+
+            IF NOT has_mapping THEN
+                SELECT grad INTO b_grad FROM llm_tensor_rt WHERE id = node.inputs[2];
+
+                IF b_grad IS NOT NULL THEN
+                    grad_rows := pg_llm_transpose(b_grad, k, n);
+                    bytes_per_row := k * 4;
+
+                    FOR token_idx IN 0..(n-1) LOOP
+                        SELECT tensor_id INTO wte_tensor_id
+                          FROM llm_tensor_map
+                         WHERE model = p_model
+                           AND name = 'wte'
+                           AND token_id = token_idx;
+
+                        IF wte_tensor_id IS NULL THEN
+                            CONTINUE;
+                        END IF;
+
+                        chunk := substring(grad_rows FROM token_idx * bytes_per_row + 1 FOR bytes_per_row);
+
+                        UPDATE llm_tensor_rt
+                           SET grad = CASE
+                                          WHEN grad IS NULL THEN chunk
+                                          ELSE pg_llm_add(grad, chunk)
+                                      END
+                         WHERE id = wte_tensor_id;
+                    END LOOP;
+                END IF;
+            END IF;
         ELSIF node.name='softmax' THEN
             UPDATE llm_tensor_rt
               SET grad = pg_llm_softmax_backward(

--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -247,7 +247,7 @@ BEGIN
         RAISE EXCEPTION 'Autograd tape empty after forward pass for step %', step_count;
     END IF;
 
-    PERFORM llm_backprop(tape_top);
+    PERFORM llm_backprop(tape_top, model);
     PERFORM llm_accumulate_grads(model);
 
     UPDATE llm_param
@@ -470,7 +470,7 @@ BEGIN;
   PERFORM llm_loss('gpt2-small', seq, target, 12, 12, 768, 50257);
 
   -- Reverse pass
-  PERFORM llm_backprop((SELECT MAX(id) FROM llm_tape));
+  PERFORM llm_backprop((SELECT MAX(id) FROM llm_tape), 'gpt2-small');
 
   -- Gradient accumulation
   PERFORM llm_accumulate_grads('gpt2-small');


### PR DESCRIPTION
## Summary
- update `llm_backprop` to detect the tied embedding projection and scatter its matmul gradient back into individual `wte` rows
- pass the model name to `llm_backprop` callers so the redistributed gradients accumulate on the correct parameters

## Testing
- make installcheck *(fails: PostgreSQL development files are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c3b9c4d883288fb88c46a4a18bf3