### PR TITLE
Add attention backward pass support

### DIFF
--- a/sql/llm_backprop.sql
+++ b/sql/llm_backprop.sql
@@ -6,6 +6,11 @@ DECLARE
     a_id INT; b_id INT;
     a BYTEA; b BYTEA;
     m INT; k INT; n INT;
+    dx BYTEA;
+    dw_qkv BYTEA;
+    db_qkv BYTEA;
+    dw_o BYTEA;
+    db_o BYTEA;
 BEGIN
     -- seed gradient of final output = 1
     UPDATE llm_tensor_rt SET grad = pg_llm_ones_like(data) WHERE id=start_id;
@@ -66,6 +71,36 @@ BEGIN
                  (SELECT data FROM llm_tensor_rt WHERE id=node.extra->>'gamma_id'),
                  (node.extra->>'eps')::FLOAT4));
     -- accumulate dx→input.grad, dγ→γ.grad, dβ→β.grad
+        ELSIF node.name='attention' THEN
+            SELECT dx, dw_qkv, db_qkv, dw_o, db_o
+              INTO dx, dw_qkv, db_qkv, dw_o, db_o
+              FROM pg_llm_attention_backward(
+                  (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[1]),
+                  (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[2]),
+                  (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[3]),
+                  (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[4]),
+                  (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[5]),
+                  (SELECT grad FROM llm_tensor_rt WHERE id=node.output),
+                  (node.extra->>'n_head')::INT,
+                  (node.extra->>'T')::INT,
+                  (node.extra->>'D')::INT)
+              AS t(dx BYTEA, dw_qkv BYTEA, db_qkv BYTEA, dw_o BYTEA, db_o BYTEA);
+
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + dx
+              WHERE id = node.inputs[1];
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + dw_qkv
+              WHERE id = node.inputs[2];
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + db_qkv
+              WHERE id = node.inputs[3];
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + dw_o
+              WHERE id = node.inputs[4];
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + db_o
+              WHERE id = node.inputs[5];
         ELSIF node.name='gelu' THEN
             UPDATE llm_tensor_rt
               SET grad = COALESCE(grad, pg_llm_zeros_like(data))

--- a/src/pg_llm.h
+++ b/src/pg_llm.h
@@ -26,6 +26,7 @@ extern Datum pg_llm_layernorm_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_dropout_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_export_npz(PG_FUNCTION_ARGS);
 extern Datum pg_llm_cross_entropy_backward(PG_FUNCTION_ARGS);
+extern Datum pg_llm_attention_backward(PG_FUNCTION_ARGS);
 
 /* Autograd instrumentation helpers */
 extern bool pg_llm_autograd_enabled(void);


### PR DESCRIPTION
## Summary
- implement a C attention backward kernel that recomputes intermediate tensors, applies the causal mask, and produces gradients for X, QKV weights/biases, and output projection parameters
- wire the new backward kernel into `llm_backprop` so gradients accumulate onto the attention inputs and parameters
- expose the new function declaration for the SQL layer

## Testing
- make *(fails: PostgreSQL PGXS makefile not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c3aa53848328a99a85819aefb3c3