### PR TITLE
Complete autograd coverage and attention backward

### DIFF
--- a/sql/llm_backprop.sql
+++ b/sql/llm_backprop.sql
@@ -3,9 +3,15 @@ RETURNS VOID AS $$
 DECLARE
     node RECORD;
     grad BYTEA;
-    a_id INT; b_id INT;
-    a BYTEA; b BYTEA;
     m INT; k INT; n INT;
+    ln_dx BYTEA;
+    ln_dgamma BYTEA;
+    ln_dbeta BYTEA;
+    attn_dx BYTEA;
+    attn_dw_qkv BYTEA;
+    attn_db_qkv BYTEA;
+    attn_dw_o BYTEA;
+    attn_db_o BYTEA;
 BEGIN
     -- seed gradient of final output = 1
     UPDATE llm_tensor_rt SET grad = pg_llm_ones_like(data) WHERE id=start_id;
@@ -59,19 +65,78 @@ BEGIN
               WHERE id=node.inputs[1];
 
         ELSIF node.name='layernorm' THEN
-            PERFORM (SELECT dx, dgamma, dbeta
-             FROM pg_llm_layernorm_backward(
-                 (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[1]),
-                 (SELECT grad FROM llm_tensor_rt WHERE id=node.output),
-                 (SELECT data FROM llm_tensor_rt WHERE id=node.extra->>'gamma_id'),
-                 (node.extra->>'eps')::FLOAT4));
-    -- accumulate dx→input.grad, dγ→γ.grad, dβ→β.grad
+            SELECT dx, dgamma, dbeta
+              INTO ln_dx, ln_dgamma, ln_dbeta
+            FROM pg_llm_layernorm_backward(
+                (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[1]),
+                (SELECT grad FROM llm_tensor_rt WHERE id=node.output),
+                (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[2]),
+                (node.extra->>'eps')::FLOAT4);
+
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + ln_dx
+              WHERE id = node.inputs[1];
+
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + ln_dgamma
+              WHERE id = node.inputs[2];
+
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + ln_dbeta
+              WHERE id = node.inputs[3];
         ELSIF node.name='gelu' THEN
             UPDATE llm_tensor_rt
               SET grad = COALESCE(grad, pg_llm_zeros_like(data))
                         + pg_llm_gelu_backward((SELECT data FROM llm_tensor_rt WHERE id=node.inputs[1]),
                                                (SELECT grad FROM llm_tensor_rt WHERE id=node.output))
               WHERE id=node.inputs[1];
+        ELSIF node.name='ones_like' THEN
+            -- constant tensor; no gradient to propagate
+            CONTINUE;
+        ELSIF node.name='zeros_like' THEN
+            -- constant tensor; no gradient to propagate
+            CONTINUE;
+        ELSIF node.name='transpose' THEN
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data))
+                        + pg_llm_transpose(
+                            (SELECT grad FROM llm_tensor_rt WHERE id=node.output),
+                            (node.extra->>'cols')::INT,
+                            (node.extra->>'rows')::INT)
+              WHERE id = node.inputs[1];
+        ELSIF node.name='attention' THEN
+            SELECT dx, dw_qkv, db_qkv, dw_o, db_o
+              INTO attn_dx, attn_dw_qkv, attn_db_qkv, attn_dw_o, attn_db_o
+            FROM pg_llm_attention_backward(
+                (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[1]),
+                (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[2]),
+                (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[3]),
+                (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[4]),
+                (SELECT data FROM llm_tensor_rt WHERE id=node.inputs[5]),
+                (SELECT grad FROM llm_tensor_rt WHERE id=node.output),
+                (node.extra->>'n_head')::INT,
+                (node.extra->>'T')::INT,
+                (node.extra->>'D')::INT);
+
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + attn_dx
+              WHERE id = node.inputs[1];
+
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + attn_dw_qkv
+              WHERE id = node.inputs[2];
+
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + attn_db_qkv
+              WHERE id = node.inputs[3];
+
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + attn_dw_o
+              WHERE id = node.inputs[4];
+
+            UPDATE llm_tensor_rt
+              SET grad = COALESCE(grad, pg_llm_zeros_like(data)) + attn_db_o
+              WHERE id = node.inputs[5];
         -- Similar for layernorm, softmax, cross_entropy etc.
         END IF;
     END LOOP;

--- a/sql/pg_llm--0.1.0.sql
+++ b/sql/pg_llm--0.1.0.sql
@@ -51,6 +51,8 @@ LANGUAGE C STRICT;
 CREATE FUNCTION pg_llm_transpose(src BYTEA, rows INT, cols INT)
 RETURNS BYTEA
 AS 'MODULE_PATHNAME', 'pg_llm_transpose'
+LANGUAGE C STRICT;
+
 CREATE FUNCTION pg_llm_dropout_backward(
     input BYTEA,
     output BYTEA,
@@ -72,6 +74,28 @@ CREATE FUNCTION pg_llm_attention(
     D INT)
 RETURNS BYTEA
 AS 'MODULE_PATHNAME', 'pg_llm_attention'
+LANGUAGE C STRICT;
+
+CREATE TYPE attention_grads AS (
+    dx BYTEA,
+    dw_qkv BYTEA,
+    db_qkv BYTEA,
+    dw_o BYTEA,
+    db_o BYTEA
+);
+
+CREATE FUNCTION pg_llm_attention_backward(
+    x BYTEA,
+    w_qkv BYTEA,
+    b_qkv BYTEA,
+    w_o BYTEA,
+    b_o BYTEA,
+    grad_output BYTEA,
+    n_head INT,
+    T INT,
+    D INT)
+RETURNS attention_grads
+AS 'MODULE_PATHNAME', 'pg_llm_attention_backward'
 LANGUAGE C STRICT;
 
 -- AdamW optimizer step

--- a/src/llm_attention.c
+++ b/src/llm_attention.c
@@ -1,4 +1,5 @@
 #include "pg_llm.h"
+#include <string.h>
 
 #define PG_LLM_ATTENTION_CHUNK 64
 
@@ -127,6 +128,7 @@ attention_compute(float *x, float *w_qkv, float *b_qkv,
  * returns: BYTEA (T×D)
  */
 PG_FUNCTION_INFO_V1(pg_llm_attention);
+PG_FUNCTION_INFO_V1(pg_llm_attention_backward);
 Datum pg_llm_attention(PG_FUNCTION_ARGS)
 {
     bytea *x_b    = PG_GETARG_BYTEA_P(0);
@@ -192,4 +194,339 @@ Datum pg_llm_attention(PG_FUNCTION_ARGS)
     }
 
     PG_RETURN_BYTEA_P(out);
+}
+
+Datum
+pg_llm_attention_backward(PG_FUNCTION_ARGS)
+{
+    bytea *x_b = PG_GETARG_BYTEA_P(0);
+    bytea *w_qkv_b = PG_GETARG_BYTEA_P(1);
+    bytea *b_qkv_b = PG_GETARG_BYTEA_P(2);
+    bytea *w_o_b = PG_GETARG_BYTEA_P(3);
+    bytea *b_o_b = PG_GETARG_BYTEA_P(4);
+    bytea *grad_out_b = PG_GETARG_BYTEA_P(5);
+    int n_head = PG_GETARG_INT32(6);
+    int T = PG_GETARG_INT32(7);
+    int D = PG_GETARG_INT32(8);
+
+    const Size td = (Size) T * (Size) D;
+    const Size threeD = (Size) 3 * (Size) D;
+    const int head_dim = (n_head > 0) ? D / n_head : 0;
+    const float scale = head_dim > 0 ? 1.0f / sqrtf((float) head_dim) : 0.0f;
+
+    float *x;
+    float *w_qkv;
+    float *b_qkv;
+    float *w_o;
+    float *grad_out;
+    bytea *dx_b_out;
+    bytea *dw_qkv_b_out;
+    bytea *db_qkv_b_out;
+    bytea *dw_o_b_out;
+    bytea *db_o_b_out;
+    float *dx;
+    float *dw_qkv;
+    float *db_qkv;
+    float *dw_o_grad;
+    float *db_o_grad;
+    float *qkv;
+    float *Q;
+    float *K;
+    float *V;
+    float *context;
+    float *dcontext;
+    float *dQ;
+    float *dK;
+    float *dV;
+    float *dqkv;
+    TupleDesc tupdesc;
+    Datum values[5];
+    bool nulls[5] = {false, false, false, false, false};
+    HeapTuple rettuple;
+
+    if (T <= 0 || D <= 0)
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward requires positive dimensions")));
+    if (n_head <= 0 || D % n_head != 0)
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward requires n_head dividing D")));
+    if ((Size) head_dim * (Size) n_head != (Size) D)
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward invalid head dimension")));
+
+    if (nbytes(x_b) != td * sizeof(float))
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward expected x to have %zu bytes", td * sizeof(float))));
+    if (nbytes(w_qkv_b) != (Size) D * threeD * sizeof(float))
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward expected w_qkv to have %zu bytes",
+                        (Size) D * threeD * sizeof(float))));
+    if (nbytes(b_qkv_b) != threeD * sizeof(float))
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward expected b_qkv to have %zu bytes",
+                        threeD * sizeof(float))));
+    if (nbytes(w_o_b) != (Size) D * (Size) D * sizeof(float))
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward expected w_o to have %zu bytes",
+                        (Size) D * (Size) D * sizeof(float))));
+    if (nbytes(b_o_b) != (Size) D * sizeof(float))
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward expected b_o to have %zu bytes",
+                        (Size) D * sizeof(float))));
+    if (nbytes(grad_out_b) != td * sizeof(float))
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward expected grad_output to have %zu bytes",
+                        td * sizeof(float))));
+
+    x = as_float(x_b);
+    w_qkv = as_float(w_qkv_b);
+    b_qkv = as_float(b_qkv_b);
+    w_o = as_float(w_o_b);
+    grad_out = as_float(grad_out_b);
+
+    dx_b_out = bytea_same_size(x_b);
+    dw_qkv_b_out = bytea_same_size(w_qkv_b);
+    db_qkv_b_out = bytea_same_size(b_qkv_b);
+    dw_o_b_out = bytea_same_size(w_o_b);
+    db_o_b_out = bytea_same_size(b_o_b);
+
+    dx = as_float(dx_b_out);
+    dw_qkv = as_float(dw_qkv_b_out);
+    db_qkv = as_float(db_qkv_b_out);
+    dw_o_grad = as_float(dw_o_b_out);
+    db_o_grad = as_float(db_o_b_out);
+
+    memset(dx, 0, td * sizeof(float));
+    memset(dw_qkv, 0, (Size) D * threeD * sizeof(float));
+    memset(db_qkv, 0, threeD * sizeof(float));
+    memset(dw_o_grad, 0, (Size) D * (Size) D * sizeof(float));
+    memset(db_o_grad, 0, (Size) D * sizeof(float));
+
+    qkv = (float *) palloc((Size) T * threeD * sizeof(float));
+    pg_llm_fast_gemm(x, w_qkv, qkv, T, D, 3 * D);
+    for (int t = 0; t < T; ++t)
+    {
+        float *row = qkv + (Size) t * 3 * D;
+        for (int j = 0; j < 3 * D; ++j)
+            row[j] += b_qkv[j];
+    }
+    Q = qkv;
+    K = qkv + (Size) T * D;
+    V = qkv + (Size) 2 * T * D;
+
+    context = (float *) palloc0(td * sizeof(float));
+    {
+        float *scores = (float *) palloc((Size) T * sizeof(float));
+        float *attn = (float *) palloc((Size) T * sizeof(float));
+        for (int h = 0; h < n_head; ++h)
+        {
+            int off = h * head_dim;
+            for (int i = 0; i < T; ++i)
+            {
+                int valid = i + 1;
+                const float *Q_row = Q + (Size) i * D + off;
+                float *ctx_row = context + (Size) i * D + off;
+                float maxv = -INFINITY;
+                for (int j = 0; j < valid; ++j)
+                {
+                    const float *K_row = K + (Size) j * D + off;
+                    float dot = 0.0f;
+                    for (int d = 0; d < head_dim; ++d)
+                        dot += Q_row[d] * K_row[d];
+                    scores[j] = dot * scale;
+                    if (scores[j] > maxv)
+                        maxv = scores[j];
+                }
+                float sum = 0.0f;
+                for (int j = 0; j < valid; ++j)
+                {
+                    float val = expf(scores[j] - maxv);
+                    attn[j] = val;
+                    sum += val;
+                }
+                float inv_sum = 1.0f / (sum > 0.0f ? sum : 1.0f);
+                memset(ctx_row, 0, head_dim * sizeof(float));
+                for (int j = 0; j < valid; ++j)
+                {
+                    const float *V_row = V + (Size) j * D + off;
+                    float weight = attn[j] * inv_sum;
+                    for (int d = 0; d < head_dim; ++d)
+                        ctx_row[d] += weight * V_row[d];
+                }
+            }
+        }
+        pfree(scores);
+        pfree(attn);
+    }
+
+    dcontext = (float *) palloc0(td * sizeof(float));
+    for (int col = 0; col < D; ++col)
+    {
+        float sum = 0.0f;
+        for (int t = 0; t < T; ++t)
+            sum += grad_out[(Size) t * D + col];
+        db_o_grad[col] = sum;
+    }
+    for (int row = 0; row < D; ++row)
+    {
+        for (int col = 0; col < D; ++col)
+        {
+            float sum = 0.0f;
+            for (int t = 0; t < T; ++t)
+                sum += context[(Size) t * D + row] * grad_out[(Size) t * D + col];
+            dw_o_grad[(Size) row * D + col] = sum;
+        }
+    }
+    for (int t = 0; t < T; ++t)
+    {
+        for (int row = 0; row < D; ++row)
+        {
+            float sum = 0.0f;
+            for (int col = 0; col < D; ++col)
+                sum += grad_out[(Size) t * D + col] * w_o[(Size) row * D + col];
+            dcontext[(Size) t * D + row] = sum;
+        }
+    }
+
+    dQ = (float *) palloc0(td * sizeof(float));
+    dK = (float *) palloc0(td * sizeof(float));
+    dV = (float *) palloc0(td * sizeof(float));
+
+    {
+        float *scores = (float *) palloc((Size) T * sizeof(float));
+        float *attn = (float *) palloc((Size) T * sizeof(float));
+        float *dattn = (float *) palloc((Size) T * sizeof(float));
+        float *dscores = (float *) palloc((Size) T * sizeof(float));
+        for (int h = 0; h < n_head; ++h)
+        {
+            int off = h * head_dim;
+            for (int i = 0; i < T; ++i)
+            {
+                int valid = i + 1;
+                const float *Q_row = Q + (Size) i * D + off;
+                const float *dctx_row = dcontext + (Size) i * D + off;
+                float *dQ_row = dQ + (Size) i * D + off;
+                float maxv = -INFINITY;
+                for (int j = 0; j < valid; ++j)
+                {
+                    const float *K_row = K + (Size) j * D + off;
+                    float dot = 0.0f;
+                    for (int d = 0; d < head_dim; ++d)
+                        dot += Q_row[d] * K_row[d];
+                    scores[j] = dot * scale;
+                    if (scores[j] > maxv)
+                        maxv = scores[j];
+                }
+                float sum = 0.0f;
+                for (int j = 0; j < valid; ++j)
+                {
+                    float val = expf(scores[j] - maxv);
+                    attn[j] = val;
+                    sum += val;
+                }
+                float inv_sum = 1.0f / (sum > 0.0f ? sum : 1.0f);
+                for (int j = 0; j < valid; ++j)
+                    attn[j] *= inv_sum;
+
+                for (int j = 0; j < valid; ++j)
+                {
+                    float *dV_row = dV + (Size) j * D + off;
+                    for (int d = 0; d < head_dim; ++d)
+                        dV_row[d] += attn[j] * dctx_row[d];
+                }
+
+                float dot = 0.0f;
+                for (int j = 0; j < valid; ++j)
+                {
+                    const float *V_row = V + (Size) j * D + off;
+                    float val = 0.0f;
+                    for (int d = 0; d < head_dim; ++d)
+                        val += dctx_row[d] * V_row[d];
+                    dattn[j] = val;
+                    dot += val * attn[j];
+                }
+                for (int j = 0; j < valid; ++j)
+                    dscores[j] = (dattn[j] - dot) * attn[j];
+
+                for (int j = 0; j < valid; ++j)
+                {
+                    const float *K_row = K + (Size) j * D + off;
+                    float coeff = dscores[j] * scale;
+                    float *dK_row = dK + (Size) j * D + off;
+                    for (int d = 0; d < head_dim; ++d)
+                    {
+                        dQ_row[d] += coeff * K_row[d];
+                        dK_row[d] += coeff * Q_row[d];
+                    }
+                }
+            }
+        }
+        pfree(scores);
+        pfree(attn);
+        pfree(dattn);
+        pfree(dscores);
+    }
+
+    dqkv = (float *) palloc0((Size) T * 3 * D * sizeof(float));
+    for (int t = 0; t < T; ++t)
+    {
+        float *dst = dqkv + (Size) t * 3 * D;
+        memcpy(dst, dQ + (Size) t * D, D * sizeof(float));
+        memcpy(dst + D, dK + (Size) t * D, D * sizeof(float));
+        memcpy(dst + 2 * D, dV + (Size) t * D, D * sizeof(float));
+    }
+
+    for (int t = 0; t < T; ++t)
+    {
+        float *dx_row = dx + (Size) t * D;
+        const float *dqkv_row = dqkv + (Size) t * 3 * D;
+        for (int di = 0; di < D; ++di)
+        {
+            float sum = 0.0f;
+            for (int j = 0; j < 3 * D; ++j)
+                sum += dqkv_row[j] * w_qkv[(Size) di * 3 * D + j];
+            dx_row[di] = sum;
+        }
+    }
+
+    for (int di = 0; di < D; ++di)
+    {
+        for (int j = 0; j < 3 * D; ++j)
+        {
+            float sum = 0.0f;
+            for (int t = 0; t < T; ++t)
+                sum += x[(Size) t * D + di] * dqkv[(Size) t * 3 * D + j];
+            dw_qkv[(Size) di * 3 * D + j] = sum;
+        }
+    }
+    for (int j = 0; j < 3 * D; ++j)
+    {
+        float sum = 0.0f;
+        for (int t = 0; t < T; ++t)
+            sum += dqkv[(Size) t * 3 * D + j];
+        db_qkv[j] = sum;
+    }
+
+    if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+        ereport(ERROR,
+                (errmsg("pg_llm_attention_backward expected composite return type")));
+    BlessTupleDesc(tupdesc);
+
+    values[0] = PointerGetDatum(dx_b_out);
+    values[1] = PointerGetDatum(dw_qkv_b_out);
+    values[2] = PointerGetDatum(db_qkv_b_out);
+    values[3] = PointerGetDatum(dw_o_b_out);
+    values[4] = PointerGetDatum(db_o_b_out);
+
+    rettuple = heap_form_tuple(tupdesc, values, nulls);
+
+    pfree(qkv);
+    pfree(context);
+    pfree(dcontext);
+    pfree(dQ);
+    pfree(dK);
+    pfree(dV);
+    pfree(dqkv);
+
+    PG_RETURN_DATUM(HeapTupleGetDatum(rettuple));
 }

--- a/src/pg_llm.h
+++ b/src/pg_llm.h
@@ -20,6 +20,8 @@ extern Datum pg_llm_dropout(PG_FUNCTION_ARGS);
 extern Datum pg_llm_ones_like(PG_FUNCTION_ARGS);
 extern Datum pg_llm_zeros_like(PG_FUNCTION_ARGS);
 extern Datum pg_llm_transpose(PG_FUNCTION_ARGS);
+extern Datum pg_llm_attention(PG_FUNCTION_ARGS);
+extern Datum pg_llm_attention_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_gelu_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_softmax_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_layernorm_backward(PG_FUNCTION_ARGS);


### PR DESCRIPTION
## Summary
- ensure all tape-recorded ops participate in backprop, including layernorm accumulation, transpose, and constants
- add a new C implementation for multi-head attention backward propagation and expose it via the extension
- register attention gradient helpers in SQL and wire them into llm_backprop

## Testing
- make *(fails: PostgreSQL development files not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c3c132dc832894245a30bda8c5b2