### PR TITLE
Implement pg_llm_mlp_backward gradient kernel

### DIFF
--- a/src/pg_llm.h
+++ b/src/pg_llm.h
@@ -29,6 +29,7 @@ extern Datum pg_llm_dropout_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_export_npz(PG_FUNCTION_ARGS);
 extern Datum pg_llm_cross_entropy_backward(PG_FUNCTION_ARGS);
 extern Datum pg_llm_attention_backward(PG_FUNCTION_ARGS);
+extern Datum pg_llm_mlp_backward(PG_FUNCTION_ARGS);
 
 /* Autograd instrumentation helpers */
 extern bool pg_llm_autograd_enabled(void);


### PR DESCRIPTION
## Summary
- add a native implementation of `pg_llm_mlp_backward` that recomputes the feed-forward forward pass and propagates gradients
- handle broadcasted and per-token biases while returning gradients for inputs, weights, and biases

## Testing
- make installcheck *(fails: PostgreSQL PGXS makefile not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e685dc9c5883288216acefb31e34d3