### PR TITLE
Add integration tests for helper scripts and workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ python scripts/prepare_dataset.py \
   --block-size 1024 --truncate
 ```
 
+An end-to-end walkthrough that stitches the helper scripts together is available
+in [docs/python_workflow.md](docs/python_workflow.md).
+
 ---
 
 ## Mathematical Fidelity

--- a/docs/python_workflow.md
+++ b/docs/python_workflow.md
@@ -1,0 +1,80 @@
+# End-to-End Helper Script Workflow
+
+This walkthrough shows how to prepare a PostgreSQL database with pretrained GPT-2
+weights, tokenizer assets, and a fine-tuning dataset using the helper scripts in
+`scripts/`.
+
+## 1. Convert HuggingFace Weights
+
+Use `convert_gpt2_checkpoint.py` to download a checkpoint from HuggingFace (or
+load one from disk) and emit the gzip-compressed archive understood by
+`pg_llm_import_npz`.
+
+```bash
+python scripts/convert_gpt2_checkpoint.py \
+    --source gpt2 \
+    --output /mnt/models/gpt2-small.npz
+```
+
+The resulting file can be imported into PostgreSQL via:
+
+```sql
+SELECT pg_llm_import_npz('/mnt/models/gpt2-small.npz', 'gpt2-small');
+```
+
+## 2. Ingest Tokenizer Vocabulary
+
+With the weights in place, load the GPT-2 tokenizer vocabulary and merge rules
+into the database using `ingest_tokenizer.py`.
+
+```bash
+python scripts/ingest_tokenizer.py \
+    --dsn postgresql://postgres@localhost:5432/postgres \
+    --model gpt2-small \
+    --vocab ./gpt2/vocab.json \
+    --merges ./gpt2/merges.txt \
+    --truncate
+```
+
+This populates `llm_bpe_vocab` and `llm_bpe_merges` so SQL functions such as
+`llm_encode` and `llm_decode` can translate text to token ids.
+
+## 3. Prepare a Training Dataset
+
+Finally, tokenize a raw text corpus and populate `llm_dataset` using
+`prepare_dataset.py`.
+
+```bash
+python scripts/prepare_dataset.py \
+    --dsn postgresql://postgres@localhost:5432/postgres \
+    --tokenizer gpt2 \
+    --input ./corpus/*.txt \
+    --block-size 1024 \
+    --batch-size 512 \
+    --truncate
+```
+
+The script loads the specified tokenizer with `transformers`, encodes the text
+files, and writes fixed-length `(tokens, target)` arrays into PostgreSQL ready
+for `llm_train`.
+
+## Putting It Together
+
+1. Convert weights (`convert_gpt2_checkpoint.py`).
+2. Load tokenizer assets (`ingest_tokenizer.py`).
+3. Populate the dataset table (`prepare_dataset.py`).
+4. Import weights and begin training or inference using the SQL functions
+   provided by the extension.
+
+Run the helper scripts from the repository root so relative paths to `scripts/`
+resolve correctly. Install the optional Python dependencies with:
+
+```bash
+pip install transformers torch psycopg[binary]
+```
+
+With the tables populated you can now train directly in SQL, for example:
+
+```sql
+SELECT llm_train('gpt2-small', 1000, 12, 12, 768, 50257, 0.9, 0.999, 1e-8, 0.01, 2.5e-4, 2000);
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,127 @@
+import os
+import pwd
+import shutil
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+
+import psycopg
+import pytest
+
+
+def _find_free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def postgres_dsn() -> str:
+    def _find_binary(name: str) -> str | None:
+        found = shutil.which(name)
+        if found:
+            return found
+        pg_root = Path("/usr/lib/postgresql")
+        if pg_root.exists():
+            for candidate in pg_root.glob(f"*/bin/{name}"):
+                if candidate.exists():
+                    return str(candidate)
+        return None
+
+    initdb_path = _find_binary("initdb")
+    pg_ctl_path = _find_binary("pg_ctl")
+    if not initdb_path or not pg_ctl_path:
+        pytest.skip("PostgreSQL binaries are not available in the environment")
+
+    data_dir = Path(tempfile.mkdtemp(prefix="pg_gpt2_pgdata_"))
+    pg_user = pwd.getpwnam("postgres")
+    os.chown(str(data_dir), pg_user.pw_uid, pg_user.pw_gid)
+
+    runuser_path = shutil.which("runuser")
+    if not runuser_path:
+        pytest.skip("runuser is required to start PostgreSQL as the postgres user")
+
+    subprocess.run(
+        [
+            runuser_path,
+            "-u",
+            "postgres",
+            "--",
+            initdb_path,
+            "-D",
+            str(data_dir),
+            "-A",
+            "trust",
+            "--username",
+            "postgres",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    pg_hba_path = Path(data_dir) / "pg_hba.conf"
+    with pg_hba_path.open("a", encoding="utf-8") as handle:
+        handle.write("host    all             all             127.0.0.1/32            trust\n")
+    os.chown(str(pg_hba_path), pg_user.pw_uid, pg_user.pw_gid)
+
+    port = _find_free_port()
+    log_file = Path(data_dir) / "postgresql.log"
+
+    env = os.environ.copy()
+    env.setdefault("LC_ALL", "C")
+    env["PGUSER"] = "postgres"
+
+    subprocess.run(
+        [
+            runuser_path,
+            "-u",
+            "postgres",
+            "--",
+            pg_ctl_path,
+            "-D",
+            str(data_dir),
+            "-l",
+            str(log_file),
+            "-o",
+            f"-F -p {port} -h 127.0.0.1",
+            "-w",
+            "start",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    dsn = f"postgresql://postgres@127.0.0.1:{port}/postgres"
+
+    try:
+        with psycopg.connect(dsn) as conn:
+            conn.execute("SELECT 1")
+        yield dsn
+    finally:
+        subprocess.run(
+            [
+                runuser_path,
+                "-u",
+                "postgres",
+                "--",
+                pg_ctl_path,
+                "-D",
+                str(data_dir),
+                "-m",
+                "fast",
+                "-w",
+                "stop",
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        shutil.rmtree(data_dir, ignore_errors=True)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,192 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import numpy as np
+import psycopg
+import pytest
+
+convert_gpt2_checkpoint = importlib.import_module("scripts.convert_gpt2_checkpoint")
+ingest_tokenizer = importlib.import_module("scripts.ingest_tokenizer")
+prepare_dataset = importlib.import_module("scripts.prepare_dataset")
+
+
+@pytest.fixture
+def schema_setup(postgres_dsn: str) -> None:
+    with psycopg.connect(postgres_dsn, autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS llm_bpe_vocab")
+        conn.execute("DROP TABLE IF EXISTS llm_bpe_merges")
+        conn.execute(
+            """
+            CREATE TABLE llm_bpe_vocab (
+                model TEXT,
+                token_id INTEGER PRIMARY KEY,
+                token TEXT,
+                score DOUBLE PRECISION,
+                bytes BYTEA
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE llm_bpe_merges (
+                model TEXT,
+                rank INTEGER PRIMARY KEY,
+                "left" TEXT,
+                "right" TEXT,
+                pair TEXT
+            )
+            """
+        )
+        conn.execute("DROP TABLE IF EXISTS llm_dataset")
+        conn.execute(
+            """
+            CREATE TABLE llm_dataset (
+                id SERIAL PRIMARY KEY,
+                tokens INTEGER[],
+                target INTEGER[]
+            )
+            """
+        )
+
+
+def test_ingest_tokenizer_cli(postgres_dsn: str, tmp_path: Path, schema_setup: None) -> None:
+    vocab_path = tmp_path / "vocab.json"
+    merges_path = tmp_path / "merges.txt"
+
+    vocab_path.write_text(json.dumps({"hello": 0, "world": 1}), encoding="utf-8")
+    merges_path.write_text("# merges\nhe llo\nwo rld\n", encoding="utf-8")
+
+    argv = [
+        "ingest_tokenizer.py",
+        "--dsn",
+        postgres_dsn,
+        "--model",
+        "test-model",
+        "--vocab",
+        str(vocab_path),
+        "--merges",
+        str(merges_path),
+        "--truncate",
+    ]
+
+    original_argv = sys.argv
+    sys.argv = argv
+    try:
+        ingest_tokenizer.main()
+    finally:
+        sys.argv = original_argv
+
+    with psycopg.connect(postgres_dsn) as conn:
+        vocab_rows = conn.execute(
+            "SELECT token_id, token, bytes FROM llm_bpe_vocab ORDER BY token_id"
+        ).fetchall()
+        merge_rows = conn.execute(
+            'SELECT rank, "left", "right" FROM llm_bpe_merges ORDER BY rank'
+        ).fetchall()
+
+    assert [(row[0], row[1]) for row in vocab_rows] == [(0, "hello"), (1, "world")]
+    assert [bytes(row[2]) for row in vocab_rows] == [b"hello", b"world"]
+    assert merge_rows == [(0, "he", "llo"), (1, "wo", "rld")]
+
+
+def test_prepare_dataset_cli(postgres_dsn: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, schema_setup: None) -> None:
+    text_path = tmp_path / "input.txt"
+    text_path.write_text("Once upon a time", encoding="utf-8")
+
+    class DummyTokenizer:
+        pad_token = None
+        eos_token = "<eos>"
+
+        @classmethod
+        def from_pretrained(cls, name: str):
+            return cls()
+
+        def encode(self, text: str):
+            return [ord(ch) % 97 for ch in text]
+
+    monkeypatch.setattr(prepare_dataset, "_lazy_import_tokenizer", lambda: DummyTokenizer)
+
+    argv = [
+        "prepare_dataset.py",
+        "--dsn",
+        postgres_dsn,
+        "--tokenizer",
+        "dummy",
+        "--input",
+        str(text_path),
+        "--block-size",
+        "4",
+        "--batch-size",
+        "2",
+        "--truncate",
+    ]
+
+    original_argv = sys.argv
+    sys.argv = argv
+    try:
+        prepare_dataset.main()
+    finally:
+        sys.argv = original_argv
+
+    with psycopg.connect(postgres_dsn) as conn:
+        rows = conn.execute("SELECT tokens, target FROM llm_dataset ORDER BY id").fetchall()
+
+    assert rows, "expected rows in llm_dataset"
+    for tokens, target in rows:
+        assert len(tokens) == len(target)
+        assert all(isinstance(t, int) for t in tokens)
+        assert all(isinstance(t, int) for t in target)
+
+
+def test_convert_checkpoint_generates_expected_npz(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyModel:
+        def state_dict(self):
+            return {
+                "transformer.wte.weight": np.ones((2, 2), dtype=np.float32),
+                "transformer.wpe.weight": np.ones((2, 2), dtype=np.float32) * 2,
+                "transformer.h.0.attn.c_attn.weight": np.ones((2, 2), dtype=np.float32) * 3,
+                "transformer.h.0.ln_1.weight": np.ones((2,), dtype=np.float32) * 4,
+                "transformer.ln_f.bias": np.ones((2,), dtype=np.float32) * 5,
+            }
+
+    class DummyAutoModel:
+        @classmethod
+        def from_pretrained(cls, source: str, revision=None, torch_dtype=None):
+            return DummyModel()
+
+    monkeypatch.setattr(
+        convert_gpt2_checkpoint, "_lazy_import_transformers", lambda: DummyAutoModel
+    )
+
+    output_path = tmp_path / "dummy.npz"
+    convert_gpt2_checkpoint.convert_checkpoint("dummy", output_path)
+
+    tensors = {}
+    with output_path.open("rb") as raw:
+        import gzip
+
+        with gzip.GzipFile(fileobj=raw, mode="rb") as gz:
+            while True:
+                name_len_bytes = gz.read(2)
+                if not name_len_bytes:
+                    break
+                name_len = int.from_bytes(name_len_bytes, "little")
+                name = gz.read(name_len).decode("utf-8")
+                array = np.load(gz, allow_pickle=False)
+                tensors[name] = array
+
+    assert set(tensors) == {
+        "h.0.attn.c_attn.weight",
+        "h.0.ln_1.weight",
+        "ln_f.bias",
+        "wpe",
+        "wte",
+    }
+    assert tensors["wte"].dtype == np.float32
+    assert tensors["h.0.attn.c_attn.weight"].shape == (2, 2)


### PR DESCRIPTION
## Summary
- document the end-to-end helper-script workflow in docs/python_workflow.md and link it from the README
- add pytest-based integration coverage for the three Python scripts, bootstrapping a temporary PostgreSQL instance
- remove the psycopg.extras dependency by providing local execute_values helpers and quoting reserved tokenizer columns

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e68617f4b8832894a9ad88f01c220c