### PR TITLE
Fix build failure: rename mul_size to avoid PostgreSQL core symbol collision

### DIFF
--- a/src/pg_llm_checkpoint.c
+++ b/src/pg_llm_checkpoint.c
@@ -36,7 +36,7 @@ static ssize_t read_npz_entry(gzFile fp, npy_header_t *hdr);
 static void gzread_exact(gzFile fp, void *dest, Size nbytes, const char *context);
 static void parse_npy_header(const char *header, npy_header_t *hdr);
 static void gzwrite_exact(gzFile fp, const void *src, Size nbytes, const char *context);
-static Size mul_size(Size a, Size b, const char *context);
+static Size checked_mul_size(Size a, Size b, const char *context);
 static void check_shape_1d(const npy_header_t *hdr, Size expected_len,
                            const model_config_t *cfg);
 static void check_shape_2d(const npy_header_t *hdr, Size expected_rows,
@@ -44,7 +44,7 @@ static void check_shape_2d(const npy_header_t *hdr, Size expected_rows,
 static void validate_block_tensor(const npy_header_t *hdr, const model_config_t *cfg);
 
 static Size
-mul_size(Size a, Size b, const char *context)
+checked_mul_size(Size a, Size b, const char *context)
 {
     if (a != 0 && b > SIZE_MAX / a)
         ereport(ERROR,
@@ -213,7 +213,7 @@ validate_block_tensor(const npy_header_t *hdr, const model_config_t *cfg)
     {
         check_shape_2d(hdr,
                        (Size) cfg->d_model,
-                       mul_size((Size) cfg->d_model, (Size) 3,
+                       checked_mul_size((Size) cfg->d_model, (Size) 3,
                                 "attention qkv weight width"),
                        cfg);
         return;
@@ -222,7 +222,7 @@ validate_block_tensor(const npy_header_t *hdr, const model_config_t *cfg)
     if (strcmp(suffix, "attn.c_attn.bias") == 0)
     {
         check_shape_1d(hdr,
-                       mul_size((Size) cfg->d_model, (Size) 3,
+                       checked_mul_size((Size) cfg->d_model, (Size) 3,
                                 "attention qkv bias length"),
                        cfg);
         return;
@@ -238,7 +238,7 @@ validate_block_tensor(const npy_header_t *hdr, const model_config_t *cfg)
     {
         check_shape_2d(hdr,
                        (Size) cfg->d_model,
-                       mul_size((Size) cfg->d_model, (Size) 4,
+                       checked_mul_size((Size) cfg->d_model, (Size) 4,
                                 "mlp fc weight width"),
                        cfg);
         return;
@@ -247,7 +247,7 @@ validate_block_tensor(const npy_header_t *hdr, const model_config_t *cfg)
     if (strcmp(suffix, "mlp.c_fc.bias") == 0)
     {
         check_shape_1d(hdr,
-                       mul_size((Size) cfg->d_model, (Size) 4,
+                       checked_mul_size((Size) cfg->d_model, (Size) 4,
                                 "mlp fc bias length"),
                        cfg);
         return;
@@ -256,7 +256,7 @@ validate_block_tensor(const npy_header_t *hdr, const model_config_t *cfg)
     if (strcmp(suffix, "mlp.c_proj.weight") == 0)
     {
         check_shape_2d(hdr,
-                       mul_size((Size) cfg->d_model, (Size) 4,
+                       checked_mul_size((Size) cfg->d_model, (Size) 4,
                                 "mlp proj weight height"),
                        (Size) cfg->d_model,
                        cfg);


### PR DESCRIPTION
## Problem

The extension currently fails to compile against PostgreSQL 16. `src/pg_llm_checkpoint.c` declares a static helper:

```c
static Size mul_size(Size a, Size b, const char *context);
```

but PostgreSQL's own server headers already declare `Size mul_size(Size s1, Size s2)` in `utils/palloc.h` (included via `postgres.h`). The conflicting signatures make the translation unit fail to build:

```
src/pg_llm_checkpoint.c:39:13: error: conflicting types for 'mul_size';
  have 'Size(Size, Size, const char *)'
note: previous declaration of 'mul_size' with type 'Size(Size, Size)'
make: *** [<builtin>: src/pg_llm_checkpoint.o] Error 1
```

Because this aborts `make`, the whole extension (and CI's build job) is broken.

## Fix

Rename the helper to `checked_mul_size`, matching the identically-purposed, overflow-checked helpers already present in `src/llm_attention.c` and `src/pg_llm_autograd.c`. No behavior change.

## Verification

`make` now completes and links `pg_llm.so` cleanly against `postgresql-server-dev-16`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYcmZxgrePtzsMWsyqGCHW)_