### PR TITLE
Fix file-descriptor leak from double gzopen in pg_llm_import_npz

### DIFF
--- a/src/pg_llm_checkpoint.c
+++ b/src/pg_llm_checkpoint.c
@@ -332,11 +332,6 @@ Datum pg_llm_import_npz(PG_FUNCTION_ARGS)
     {
         load_model_config(model, &cfg);
 
-        fp = gzopen(path, "rb");
-        if (!fp)
-            ereport(ERROR,
-                    (errmsg("could not open %s", path)));
-
         while (true)
         {
             npy_header_t hdr;


### PR DESCRIPTION
## Problem

`pg_llm_import_npz` opens the checkpoint file **twice**:

```c
fp = gzopen(path, "rb");           // (1) before PG_TRY
if (!fp) { ... ereport(ERROR); }

PG_TRY();
{
    load_model_config(model, &cfg);

    fp = gzopen(path, "rb");       // (2) inside PG_TRY — overwrites (1)
    if (!fp) ereport(ERROR, ...);
    ...
```

The second `gzopen` overwrites the handle from the first, so the first `gzFile` is never closed — leaking a file descriptor on every successful import. `load_model_config` only issues SPI queries between the two opens, so it never touched the first handle.

## Fix

Remove the redundant second `gzopen`. The handle opened before `PG_TRY` is already valid at the start of the block, already positioned at the beginning of the file, and already covered by the `PG_CATCH` cleanup (`if (fp) gzclose(fp);`).

## Verification

`src/pg_llm_checkpoint.c` compiles cleanly. The import loop reads from the start of the file exactly as before, now with a single descriptor.

> Note: depends on #93 (build fix) — this file does not compile on `main` until that lands, which is why this PR targets that branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYcmZxgrePtzsMWsyqGCHW)_