### PR TITLE
Clamp cosine LR schedule so it does not rise after the final step

### DIFF
--- a/src/pg_llm_optim.c
+++ b/src/pg_llm_optim.c
@@ -179,6 +179,13 @@ Datum pg_llm_lr_schedule(PG_FUNCTION_ARGS)
         lr = lr_max * (float)step / (float)warmup;
     else {
         float progress = (float)(step - warmup) / (float)(total - warmup);
+        /*
+         * Clamp progress to the [0, 1] cosine half-period. Past the final
+         * step the raw ratio exceeds 1.0, which would send cos() back up and
+         * make the learning rate rise again after decaying to its floor.
+         */
+        if (progress > 1.0f)
+            progress = 1.0f;
         lr = 0.5f * lr_max * (1.0f + cosf(M_PI * progress));
     }
     PG_RETURN_FLOAT4(lr);


### PR DESCRIPTION
## Problem

`pg_llm_lr_schedule` implements cosine decay with warmup:

```c
float progress = (float)(step - warmup) / (float)(total - warmup);
lr = 0.5f * lr_max * (1.0f + cosf(M_PI * progress));
```

`progress` is never bounded. At `step == total` it equals `1.0` and the LR correctly reaches its floor (`0.5 * lr_max * (1 + cos(pi)) == 0`). But for **any `step > total`**, `progress > 1.0`, so `cos(pi * progress)` swings back upward and the learning rate *increases again* after decaying.

The training loop (`llm_train_step` in `sql/pg_llm--0.1.0.sql`) derives `step` from the running step count, so a run that continues past `total_steps` gets a rising LR instead of a held floor.

## Fix

Clamp `progress` to at most `1.0` before the cosine. In the `else` branch `step >= warmup`, so `progress >= 0` already holds; only the upper bound was missing. This matches the standard cosine-with-warmup schedule (LR stays at the floor once the final step is reached).

## Verification

`src/pg_llm_optim.c` compiles cleanly. Behavior for `step <= total` is unchanged; `step > total` now holds at the floor.

> Note: depends on #93 (build fix) for a green CI build, which is why this PR targets that branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYcmZxgrePtzsMWsyqGCHW)_