### PR TITLE
Replace O(n^2) top-p sort with O(n log n) qsort in pg_llm_sample

### DIFF
--- a/src/pg_llm_sample.c
+++ b/src/pg_llm_sample.c
@@ -16,6 +16,29 @@ compare_desc_float(const void *a, const void *b)
     return 0;
 }
 
+/*
+ * Order token indices by descending probability, breaking ties by ascending
+ * index so the ordering is deterministic. Used with qsort_arg (arg is the
+ * probability array) to sort candidates for top-p pruning in O(n log n).
+ */
+static int
+compare_idx_by_prob_desc(const void *a, const void *b, void *arg)
+{
+    const float *p = (const float *) arg;
+    int ia = *(const int *) a;
+    int ib = *(const int *) b;
+
+    if (p[ia] < p[ib])
+        return 1;
+    if (p[ia] > p[ib])
+        return -1;
+    if (ia < ib)
+        return -1;
+    if (ia > ib)
+        return 1;
+    return 0;
+}
+
 PG_FUNCTION_INFO_V1(pg_llm_sample);
 
 /*
@@ -69,10 +92,8 @@ Datum pg_llm_sample(PG_FUNCTION_ARGS)
         float cum = 0;
         float s = 0;
         for(int i=0;i<n;++i) idx[i]=i;
-        /* sort indices by prob desc */
-        for(int i=0;i<n-1;++i)
-            for(int j=i+1;j<n;++j)
-                if(p[idx[j]]>p[idx[i]]){int t=idx[i];idx[i]=idx[j];idx[j]=t;}
+        /* sort indices by prob desc (O(n log n) instead of O(n^2)) */
+        qsort_arg(idx, n, sizeof(int), compare_idx_by_prob_desc, p);
         for(int k=0;k<n;++k){
             cum+=p[idx[k]];
             if(cum>topp){


### PR DESCRIPTION
## Problem

Top-p (nucleus) pruning in `pg_llm_sample` sorts the candidate indices with a hand-written selection sort:

```c
for(int i=0;i<n-1;++i)
    for(int j=i+1;j<n;++j)
        if(p[idx[j]]>p[idx[i]]){int t=idx[i];idx[i]=idx[j];idx[j]=t;}
```

This is **O(n²)** in the vocabulary size `n`. For GPT-2's 50257-token vocabulary that's ~1.3 billion comparisons for *every sampled token*, which dominates generation latency whenever `topp` is in `(0, 1)`.

## Fix

Sort the index array with PostgreSQL's `qsort_arg`, passing the probability array as the comparator context. The comparator orders by descending probability and breaks ties by ascending index, preserving the deterministic, stable descending order the selection sort produced.

## Verification

- Full extension builds and links cleanly against `postgresql-server-dev-16`.
- The `llm_sampling` regression case (`topp=0.2` over `[0,1,2,3]`) uses strictly-distinct probabilities, so the sorted order — and therefore the pruning result and sampled token — is identical to the previous implementation. Tie-break-by-index keeps ordering deterministic for the general case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYcmZxgrePtzsMWsyqGCHW)_